### PR TITLE
49 add support for irregular token id numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ yarn-error.log*
 
 # pem files used for local https
 *.pem
+
+# generated file when react app starts
+src/constants/tokenIds.json

--- a/getTokenIds.js
+++ b/getTokenIds.js
@@ -1,0 +1,66 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
+const { ADDRESS_ZERO, tokenKinds } = require('@airswap/constants');
+const ethers = require('ethers');
+
+const { abi: ERC165_ABI } = require('@openzeppelin/contracts/build/contracts/ERC165.json');
+const { abi: ERC721_ABI } = require('@openzeppelin/contracts/build/contracts/ERC721.json');
+const { abi: ERC1155_ABI } = require('@openzeppelin/contracts/build/contracts/ERC1155.json');
+
+const address = process.argv[2];
+const network = process.argv[3];
+const apikey = process.argv[4];
+
+/* sanity check */
+if (!address || !network) console.log("Incorrect arguments...");
+if (!ethers.utils.isAddress(address)) throw new Error(`Invalid address: ${address}`);
+
+/* initialization */
+let provider = !apikey ? ethers.getDefaultProvider(network) : ethers.providers.InfuraProvider.getWebSocketProvider(network, apikey);
+const contract = new ethers.Contract(address, ERC165_ABI, provider);
+
+/* if contract is ERC721 */
+contract.supportsInterface(tokenKinds.ERC721).then((isERC721) => {
+  if (!isERC721) return;
+
+  const collectionContract = new ethers.Contract(address, ERC721_ABI, provider);
+  const transferFilter = collectionContract.filters.Transfer(ADDRESS_ZERO);
+
+  collectionContract.queryFilter(transferFilter, 0).then(events => {
+    /* get token ids from past events */
+    const tokenIds = events.map(e => e.args?.at(2).toString());
+
+    /* get unique values */
+    const uniqueTokenIds = tokenIds.filter((element, index) => {
+      return tokenIds.indexOf(element) === index;
+    });
+
+    /* write token ids in a json file */
+    fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(uniqueTokenIds));
+
+    process.exit(0);
+  });
+});
+
+/* if contract is ERC1155 */
+contract.supportsInterface(tokenKinds.ERC1155).then((isERC1155) => {
+  if (!isERC1155) return;
+
+  const collectionContract = new ethers.Contract(address, ERC1155_ABI, provider);
+  const transferFilter = collectionContract.filters.TransferSingle(null, ADDRESS_ZERO);
+
+  collectionContract.queryFilter(transferFilter, 0).then(events => {
+    /* get token ids from past events */
+    const tokenIds = events.map(e => e.args?.at(3).toString());
+
+    /* get unique values */
+    const uniqueTokenIds = tokenIds.filter((element, index) => {
+      return tokenIds.indexOf(element) === index;
+    });
+
+    /* write token ids in a json file */
+    fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(uniqueTokenIds));
+
+    process.exit(0);
+  });
+});

--- a/getTokenIds.js
+++ b/getTokenIds.js
@@ -37,8 +37,14 @@ contract.supportsInterface(tokenKinds.ERC721).then((isERC721) => {
     /* get unique values */
     const uniqueTokenIds = tokenIds.filter((element, index) => tokenIds.indexOf(element) === index);
 
+    const objToWrite = {
+      address,
+      tokenIds: uniqueTokenIds,
+      length: uniqueTokenIds.length,
+    };
+
     /* write token ids in a json file */
-    fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(uniqueTokenIds));
+    fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(objToWrite, null, 2));
 
     process.exit(0);
   });
@@ -58,8 +64,14 @@ contract.supportsInterface(tokenKinds.ERC1155).then((isERC1155) => {
     /* get unique values */
     const uniqueTokenIds = tokenIds.filter((element, index) => tokenIds.indexOf(element) === index);
 
+    const objToWrite = {
+      address,
+      tokenIds: uniqueTokenIds,
+      length: uniqueTokenIds.length,
+    };
+
     /* write token ids in a json file */
-    fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(uniqueTokenIds));
+    fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(objToWrite, null, 2));
 
     process.exit(0);
   });

--- a/getTokenIds.js
+++ b/getTokenIds.js
@@ -1,22 +1,26 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
-const { ADDRESS_ZERO, tokenKinds } = require('@airswap/constants');
 const ethers = require('ethers');
+const dotenv = require('dotenv');
+
+const { ADDRESS_ZERO, tokenKinds } = require('@airswap/constants');
 
 const { abi: ERC165_ABI } = require('@openzeppelin/contracts/build/contracts/ERC165.json');
 const { abi: ERC721_ABI } = require('@openzeppelin/contracts/build/contracts/ERC721.json');
 const { abi: ERC1155_ABI } = require('@openzeppelin/contracts/build/contracts/ERC1155.json');
 
-const address = process.argv[2];
-const network = process.argv[3];
-const apikey = process.argv[4];
+/* load env variables */
+dotenv.config();
 
-/* sanity check */
-if (!address || !network) console.log("Incorrect arguments...");
+const address = process.env.REACT_APP_COLLECTION_TOKEN;
+const network = ethers.providers.getNetwork(process.env.REACT_APP_CHAIN_ID);
+const apikey = process.env.REACT_APP_INFURA_API_KEY;
+
+/* check address */
 if (!ethers.utils.isAddress(address)) throw new Error(`Invalid address: ${address}`);
 
 /* initialization */
-let provider = !apikey ? ethers.getDefaultProvider(network) : ethers.providers.InfuraProvider.getWebSocketProvider(network, apikey);
+const provider = !apikey ? ethers.getDefaultProvider(network) : ethers.providers.InfuraProvider.getWebSocketProvider(network, apikey);
 const contract = new ethers.Contract(address, ERC165_ABI, provider);
 
 /* if contract is ERC721 */
@@ -31,9 +35,7 @@ contract.supportsInterface(tokenKinds.ERC721).then((isERC721) => {
     const tokenIds = events.map(e => e.args?.at(2).toString());
 
     /* get unique values */
-    const uniqueTokenIds = tokenIds.filter((element, index) => {
-      return tokenIds.indexOf(element) === index;
-    });
+    const uniqueTokenIds = tokenIds.filter((element, index) => tokenIds.indexOf(element) === index);
 
     /* write token ids in a json file */
     fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(uniqueTokenIds));
@@ -54,9 +56,7 @@ contract.supportsInterface(tokenKinds.ERC1155).then((isERC1155) => {
     const tokenIds = events.map(e => e.args?.at(3).toString());
 
     /* get unique values */
-    const uniqueTokenIds = tokenIds.filter((element, index) => {
-      return tokenIds.indexOf(element) === index;
-    });
+    const uniqueTokenIds = tokenIds.filter((element, index) => tokenIds.indexOf(element) === index);
 
     /* write token ids in a json file */
     fs.writeFileSync('src/constants/tokenIds.json', JSON.stringify(uniqueTokenIds));

--- a/getTokenIds.js
+++ b/getTokenIds.js
@@ -39,7 +39,7 @@ contract.supportsInterface(tokenKinds.ERC721).then((isERC721) => {
 
     const objToWrite = {
       address,
-      tokenIds: uniqueTokenIds,
+      ids: uniqueTokenIds,
       length: uniqueTokenIds.length,
     };
 
@@ -66,7 +66,7 @@ contract.supportsInterface(tokenKinds.ERC1155).then((isERC1155) => {
 
     const objToWrite = {
       address,
-      tokenIds: uniqueTokenIds,
+      ids: uniqueTokenIds,
       length: uniqueTokenIds.length,
     };
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bignumber.js": "^9.1.1",
     "classnames": "^2.3.2",
     "craco-plugin-env": "^1.0.5",
+    "dotenv": "^16.0.3",
     "erc-20-abi": "^1.0.0",
     "eth-rpc-errors": "^4.0.3",
     "ethers": "^5.7.2",
@@ -41,7 +42,8 @@
     "web-vitals": "^2.1.0"
   },
   "scripts": {
-    "start": "craco start",
+    "getTokenIds": "node getTokenIds.js",
+    "start": "yarn getTokenIds && craco start",
     "build": "craco build",
     "test": "craco test",
     "eject": "react-scripts eject"

--- a/src/constants/collection.ts
+++ b/src/constants/collection.ts
@@ -1,0 +1,1 @@
+export const CHUNK_SIZE = 20;

--- a/src/redux/stores/collection/collectionApi.ts
+++ b/src/redux/stores/collection/collectionApi.ts
@@ -3,6 +3,8 @@ import { TokenInfo } from '@airswap/typescript';
 import { Web3Provider } from '@ethersproject/providers';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
+import { CHUNK_SIZE } from '../../../constants/collection';
+import { ids as tokenIds, length as tokenIdsLength } from '../../../constants/tokenIds.json';
 import { CollectionToken } from '../../../entities/CollectionToken/CollectionToken';
 import { transformNFTTokenToCollectionToken } from '../../../entities/CollectionToken/CollectionTokenTransformers';
 
@@ -16,10 +18,12 @@ export const fetchCollectionTokens = createAsyncThunk<(
 CollectionToken | undefined)[], fetchNFTMetadataParams>(
   'collection/fetchNFTMetadata',
   async ({ library, collectionToken, startIndex }) => {
-    const CHUNK_SIZE = 20;
-    const tokensToFetch = new Array(CHUNK_SIZE)
-      .fill(null)
-      .map((value, index) => startIndex + index);
+    const stopIndex = startIndex + CHUNK_SIZE < tokenIdsLength ? startIndex + CHUNK_SIZE : tokenIdsLength;
+
+    const tokensToFetch = tokenIds.slice(
+      startIndex,
+      stopIndex,
+    ).map(tokenId => +tokenId);
 
     const dataPromises = tokensToFetch.map(async (tokenId) => {
       let tokenInfo: TokenInfo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5729,6 +5729,11 @@ dotenv@^10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
+dotenv@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
+  integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
+
 duplexer@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"


### PR DESCRIPTION
# Description

Created a script that should be called before the application starts. IT will generate a JSON file that contains all the token ids from a collection. This file will be used to load the NFTs in the application.

The script does not require any parameters to run. It will load the env variables using the dotenv package.

# Demo

None.

# Steps to test the change

1. Add environment variable `REACT_APP_INFURA_API_KEY` in .env file. Should also work without this, but slower.
2. yarn start (this script will also generate the `src/constants/tokenIds.json` file

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented the parts where my code is hard to understand
- [ ] I have documentated my new feature/change