### PR TITLE
etherscan owned tokens by account url fixed

### DIFF
--- a/src/helpers/airswap/getOwnedTokensByAccountUrl.ts
+++ b/src/helpers/airswap/getOwnedTokensByAccountUrl.ts
@@ -4,7 +4,7 @@ const getOwnedTokensByAccountUrl = (chainId: number, account: string, contract: 
   const accountUrl = getAccountUrl(chainId, account);
   const [etherScanUrl] = accountUrl.split('/address/');
 
-  return `${etherScanUrl}/token/${contract}?a=${account}`;
+  return `${etherScanUrl}/tokenholdings/${contract}?a=${account}`;
 };
 
 export default getOwnedTokensByAccountUrl;


### PR DESCRIPTION
# Description

Token holdings etherscan url fixed from: 
https://etherscan.io/token?a={userAddress}
to
https://etherscan.io/tokenholdings?a={userAddress}
on profile page.

# Steps to test the change
1. Go to profile page
2. Click on arrow icon link that goes to etherscan page

# Checklist:
- [x] I have read and understood [CONTRIBUTING.MD](https://github.com/airswap/airswap-marketplace/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have commented the parts where my code is hard to understand
