### PR TITLE
131: Added toast when indexers are down

### DIFF
--- a/src/redux/stores/collection/collectionApi.ts
+++ b/src/redux/stores/collection/collectionApi.ts
@@ -26,6 +26,6 @@ AppThunkApiConfig
   } catch {
     dispatch(addGetOrderFailedToast());
 
-    return [];
+    throw new Error('Failed to get orders');
   }
 });

--- a/src/redux/stores/collection/collectionApi.ts
+++ b/src/redux/stores/collection/collectionApi.ts
@@ -3,6 +3,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { AppThunkApiConfig } from '../../store';
 import { getOrdersFromIndexers } from '../indexer/indexerHelpers';
+import { addGetOrderFailedToast } from '../toasts/toastsActions';
 import { setOffset } from './collectionSlice';
 
 export const getCollectionOrders = createAsyncThunk<
@@ -16,9 +17,15 @@ AppThunkApiConfig
 
   dispatch(setOffset(filter.limit + filter.offset));
 
-  return getOrdersFromIndexers({
-    ...filter,
-    signerTokens: [collectionToken],
-    senderTokens: [currencyToken],
-  }, indexer.urls);
+  try {
+    return await getOrdersFromIndexers({
+      ...filter,
+      signerTokens: [collectionToken],
+      senderTokens: [currencyToken],
+    }, indexer.urls);
+  } catch {
+    dispatch(addGetOrderFailedToast());
+
+    return [];
+  }
 });

--- a/src/redux/stores/collection/collectionSlice.ts
+++ b/src/redux/stores/collection/collectionSlice.ts
@@ -5,6 +5,7 @@ import { INDEXER_ORDERS_OFFSET } from '../../../constants/indexer';
 import { getCollectionOrders } from './collectionApi';
 
 export interface CollectionState {
+  hasServerError: boolean;
   isTotalOrdersReached: boolean;
   offset: number;
   orders: FullOrder[];
@@ -12,6 +13,7 @@ export interface CollectionState {
 }
 
 const initialState: CollectionState = {
+  hasServerError: false,
   isTotalOrdersReached: false,
   offset: 0,
   orders: [],
@@ -51,6 +53,8 @@ export const collectionSlice = createSlice({
     }));
     builder.addCase(getCollectionOrders.rejected, (state): CollectionState => ({
       ...state,
+      hasServerError: true,
+      isTotalOrdersReached: true,
       isLoading: false,
     }));
   },

--- a/src/redux/stores/orderDetail/orderDetailApi.ts
+++ b/src/redux/stores/orderDetail/orderDetailApi.ts
@@ -3,22 +3,29 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { AppThunkApiConfig } from '../../store';
 import { getOrdersFromIndexers } from '../indexer/indexerHelpers';
+import { addGetOrderFailedToast } from '../toasts/toastsActions';
 
 export const getNftOrderByOrderNonce = createAsyncThunk<
 FullOrder | undefined,
 string,
 AppThunkApiConfig
->('orderDetail/getNftOrderByNonce', async (orderNonce, { getState }) => {
+>('orderDetail/getNftOrderByNonce', async (orderNonce, { dispatch, getState }) => {
   const { indexer } = getState();
 
-  const orders = await getOrdersFromIndexers(
-    {
-      nonce: orderNonce,
-      offset: 0,
-      limit: 999,
-    },
-    indexer.urls,
-  );
+  try {
+    const orders = await getOrdersFromIndexers(
+      {
+        nonce: orderNonce,
+        offset: 0,
+        limit: 999,
+      },
+      indexer.urls,
+    );
 
-  return orders[0];
+    return orders[0];
+  } catch {
+    dispatch(addGetOrderFailedToast());
+
+    return undefined;
+  }
 });

--- a/src/redux/stores/orderDetail/orderDetailSlice.ts
+++ b/src/redux/stores/orderDetail/orderDetailSlice.ts
@@ -46,6 +46,7 @@ export const OrderDetailSlice = createSlice({
     builder.addCase(getNftOrderByOrderNonce.rejected, (state): OrderDetailState => ({
       ...state,
       isLoading: false,
+      isOrderNotFound: true,
     }));
   },
 });

--- a/src/redux/stores/profileOrders/profileOrdersApi.ts
+++ b/src/redux/stores/profileOrders/profileOrdersApi.ts
@@ -3,6 +3,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { AppThunkApiConfig } from '../../store';
 import { getOrdersFromIndexers } from '../indexer/indexerHelpers';
+import { addGetOrderFailedToast } from '../toasts/toastsActions';
 import { setOrdersOffset } from './profileOrdersSlice';
 
 export const getProfileOrders = createAsyncThunk<
@@ -12,7 +13,13 @@ AppThunkApiConfig
 >('profileOrders/getProfileOrders', async (filter, { dispatch, getState }) => {
   const { indexer } = getState();
 
-  dispatch(setOrdersOffset(filter.limit + filter.offset));
+  try {
+    dispatch(setOrdersOffset(filter.limit + filter.offset));
 
-  return getOrdersFromIndexers(filter, indexer.urls);
+    return await getOrdersFromIndexers(filter, indexer.urls);
+  } catch {
+    dispatch(addGetOrderFailedToast());
+
+    return [];
+  }
 });

--- a/src/redux/stores/profileOrders/profileOrdersApi.ts
+++ b/src/redux/stores/profileOrders/profileOrdersApi.ts
@@ -20,6 +20,6 @@ AppThunkApiConfig
   } catch {
     dispatch(addGetOrderFailedToast());
 
-    return [];
+    throw new Error('Failed to get orders');
   }
 });

--- a/src/redux/stores/profileOrders/profileOrdersSlice.ts
+++ b/src/redux/stores/profileOrders/profileOrdersSlice.ts
@@ -5,6 +5,7 @@ import { INDEXER_ORDERS_OFFSET } from '../../../constants/indexer';
 import { getProfileOrders } from './profileOrdersApi';
 
 export interface ProfileOrdersState {
+  hasServerError: boolean;
   isLoading: boolean;
   isTotalOrdersReached: boolean;
   offset: number;
@@ -12,6 +13,7 @@ export interface ProfileOrdersState {
 }
 
 const initialState: ProfileOrdersState = {
+  hasServerError: false,
   isLoading: false,
   isTotalOrdersReached: false,
   offset: 0,
@@ -56,6 +58,8 @@ const profileSlice = createSlice({
 
       return {
         ...state,
+        hasServerError: true,
+        isTotalOrdersReached: true,
         isLoading: false,
       };
     });

--- a/src/redux/stores/toasts/toastsActions.ts
+++ b/src/redux/stores/toasts/toastsActions.ts
@@ -60,6 +60,16 @@ export const addUserRejectedToast = () => async (dispatch: AppDispatch): Promise
   }));
 };
 
+export const addGetOrderFailedToast = () => async (dispatch: AppDispatch): Promise<void> => {
+  dispatch(addToast({
+    type: ToastType.fail,
+    id: crypto.randomUUID(),
+    title: 'Server error',
+    text: 'Failed to get orders from indexers',
+    willAutomaticallyHide: true,
+  }));
+};
+
 export const addInfoToast = (title: string, text: string) => async (dispatch: AppDispatch): Promise<void> => {
   dispatch(addToast({
     type: ToastType.info,

--- a/src/widgets/CollectionWidget/helpers/getListCallToActionText.ts
+++ b/src/widgets/CollectionWidget/helpers/getListCallToActionText.ts
@@ -1,4 +1,8 @@
-const getListCallToActionText = (searchValue: string, userHasTokens: boolean): string => {
+const getListCallToActionText = (searchValue: string, userHasTokens: boolean, hasServerError: boolean): string => {
+  if (hasServerError) {
+    return 'Unable to fetch listings.';
+  }
+
   if (searchValue.length) {
     return 'No listing results. Try another search term.';
   }

--- a/src/widgets/CollectionWidget/subcomponents/ConnectedCollectionWidget/ConnectedCollectionWidget.tsx
+++ b/src/widgets/CollectionWidget/subcomponents/ConnectedCollectionWidget/ConnectedCollectionWidget.tsx
@@ -31,6 +31,7 @@ const ConnectedCollectionWidget: FC<ConnectedCollectionWidgetProps> = ({ currenc
   const { collectionImage, collectionToken, collectionName } = useAppSelector((state) => state.config);
   const { tokens: userTokens } = useAppSelector((state) => state.balances);
   const {
+    hasServerError,
     isLoading,
     isTotalOrdersReached,
     offset,
@@ -70,7 +71,7 @@ const ConnectedCollectionWidget: FC<ConnectedCollectionWidgetProps> = ({ currenc
 
       return orderToken ? filterCollectionTokenBySearchValue(orderToken, searchValue) : true;
     })), [orders, tokens, searchValue]);
-  const listCallToActionText = getListCallToActionText(searchValue, !!userTokens.length);
+  const listCallToActionText = getListCallToActionText(searchValue, !!userTokens.length, hasServerError);
 
   return (
     <div className={`collection-widget ${className}`}>
@@ -91,7 +92,7 @@ const ConnectedCollectionWidget: FC<ConnectedCollectionWidgetProps> = ({ currenc
           {searchValue ? 'Search results' : 'All listings'}
         </h2>
         <OrdersContainer
-          hasListCallToActionButton={!!userTokens.length}
+          hasListCallToActionButton={!!userTokens.length && !hasServerError}
           isEndOfOrders={isTotalOrdersReached}
           isLoading={isLoading || offset === 0}
           currencyTokenInfo={currencyTokenInfo}

--- a/src/widgets/ProfileOrdersWidget/helpers/getListCallToActionText.ts
+++ b/src/widgets/ProfileOrdersWidget/helpers/getListCallToActionText.ts
@@ -1,4 +1,8 @@
-const getListCallToActionText = (searchValue: string, userHasOrders: boolean): string => {
+const getListCallToActionText = (searchValue: string, userHasOrders: boolean, hasServerError: boolean): string => {
+  if (hasServerError) {
+    return 'Unable to fetch listings.';
+  }
+
   if (userHasOrders && searchValue.length) {
     return 'No listing results. Try another search term.';
   }

--- a/src/widgets/ProfileOrdersWidget/subcomponents/ConnectedProfileOrdersWidget/ConnectedProfileOrdersWidget.tsx
+++ b/src/widgets/ProfileOrdersWidget/subcomponents/ConnectedProfileOrdersWidget/ConnectedProfileOrdersWidget.tsx
@@ -44,6 +44,7 @@ const ConnectedProfileOrdersWidget: FC<ConnectedProfileOrdersWidgetProps> = ({
   const { tokens: userTokens } = useAppSelector((state) => state.balances);
   const { avatarUrl } = useAppSelector((state) => state.user);
   const {
+    hasServerError,
     isLoading,
     isTotalOrdersReached,
     offset,
@@ -65,7 +66,7 @@ const ConnectedProfileOrdersWidget: FC<ConnectedProfileOrdersWidgetProps> = ({
       return orderToken ? filterCollectionTokenBySearchValue(orderToken, searchValue) : true;
     })), [orders, tokens, searchValue]);
   const userIsProfileAccount = account === profileAccount;
-  const listCallToActionText = getListCallToActionText(searchValue, !!orders.length);
+  const listCallToActionText = getListCallToActionText(searchValue, !!orders.length, hasServerError);
 
   const getOrders = () => {
     if (isLoading || isTotalOrdersReached) {
@@ -112,7 +113,7 @@ const ConnectedProfileOrdersWidget: FC<ConnectedProfileOrdersWidgetProps> = ({
           className="profile-orders-widget__search-input"
         />
         <OrdersContainer
-          hasListCallToActionButton={!!userTokens.length && userIsProfileAccount}
+          hasListCallToActionButton={!!userTokens.length && userIsProfileAccount && !hasServerError}
           isEndOfOrders={isTotalOrdersReached}
           isLoading={isLoading || offset === 0}
           currencyTokenInfo={currencyTokenInfo}


### PR DESCRIPTION
# Description

Fixes #131 

https://github.com/airswap/airswap-marketplace/assets/86911296/551219dc-d3f9-4b79-8168-137cb051e73e

# Steps to test

In `indexerSlice.ts` change line 37 to:
```
urls: action.payload.map((url) => `${url}xxx`),` 
```
This way indexers will fail and failed toasts will get triggered.