### PR TITLE
205: Demo mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,5 @@ REACT_APP_RPC_URL_5=
 REACT_APP_RPC_URL_11155111=
 # [Optional] Project ID for WalletConnect support
 REACT_APP_WALLET_CONNECT_PROJECT_ID=
+# [Optional] Address for impersonating account for demoing purposes
+REACT_APP_IMPERSONATE_ADDRESS=

--- a/src/components/WalletInfo/WalletInfo.tsx
+++ b/src/components/WalletInfo/WalletInfo.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 
 import classNames from 'classnames';
 
+import IconButton from '../../compositions/IconButton/IconButton';
 import { truncateAddress } from '../../helpers/string';
 import Avatar from '../Avatar/Avatar';
 import Icon from '../Icon/Icon';
@@ -10,20 +11,24 @@ import './WalletInfo.scss';
 
 interface WalletInfoProps {
   isBanner?: boolean;
+  showLogOutButton?: boolean;
   accountUrl?: string;
   address?: string;
   avatarUrl?: string;
   ensAddress?: string;
+  onLogoutButtonClick?: () => void;
   className?: string;
   avatarClassName?: string;
 }
 
 const WalletInfo: FC<WalletInfoProps> = ({
   isBanner = false,
+  showLogOutButton,
   accountUrl,
   address = '',
   avatarUrl = '',
   ensAddress = '',
+  onLogoutButtonClick,
   className = '',
   avatarClassName = '',
 }) => {
@@ -52,6 +57,16 @@ const WalletInfo: FC<WalletInfoProps> = ({
             className="wallet-info__icon"
           />
         </a>
+      )}
+      {showLogOutButton && (
+        <IconButton
+          hideLabel
+          icon="logout"
+          text="logout"
+          onClick={onLogoutButtonClick}
+          iconClassName="wallet-info__icon"
+          className="wallet-info__button"
+        />
       )}
     </div>
   );

--- a/src/compositions/MobileMenu/MobileMenu.tsx
+++ b/src/compositions/MobileMenu/MobileMenu.tsx
@@ -14,6 +14,7 @@ interface MobileMenuProp {
   address: string;
   ensAddress?: string | undefined;
   onNavLinkClick: () => void;
+  onLogoutButtonClick: () => void;
   className?: string;
 }
 
@@ -23,6 +24,7 @@ const MobileMenu: FC<MobileMenuProp> = ({
   address,
   ensAddress,
   onNavLinkClick,
+  onLogoutButtonClick,
   className = '',
 }) => {
   const mobileMenuClassName = classNames('mobile-menu', {
@@ -35,6 +37,8 @@ const MobileMenu: FC<MobileMenuProp> = ({
         avatarUrl={avatarUrl}
         address={address}
         ensAddress={ensAddress}
+        showLogOutButton
+        onLogoutButtonClick={onLogoutButtonClick}
       />
       <div className="mobile-menu__nav-links">
         <NavLink

--- a/src/compositions/MobileMenu/MobileMenu.tsx
+++ b/src/compositions/MobileMenu/MobileMenu.tsx
@@ -3,6 +3,7 @@ import React, { FC } from 'react';
 import classNames from 'classnames';
 import { NavLink } from 'react-router-dom';
 
+import Button from '../../components/Button/Button';
 import WalletInfo from '../../components/WalletInfo/WalletInfo';
 import { routes } from '../../routes';
 
@@ -10,19 +11,23 @@ import './MobileMenu.scss';
 
 interface MobileMenuProp {
   isHidden: boolean;
+  showDisableDemoAccountButton: boolean;
   avatarUrl?: string;
   address: string;
   ensAddress?: string | undefined;
+  onDisableDemoAccountButtonClick: () => void;
   onNavLinkClick: () => void;
   onLogoutButtonClick: () => void;
   className?: string;
 }
 
 const MobileMenu: FC<MobileMenuProp> = ({
-  avatarUrl,
   isHidden,
+  showDisableDemoAccountButton,
+  avatarUrl,
   address,
   ensAddress,
+  onDisableDemoAccountButtonClick,
   onNavLinkClick,
   onLogoutButtonClick,
   className = '',
@@ -62,6 +67,13 @@ const MobileMenu: FC<MobileMenuProp> = ({
         >
           List a Token
         </NavLink>
+        {showDisableDemoAccountButton && (
+          <Button
+            text="Disable Demo Account"
+            onClick={onDisableDemoAccountButtonClick}
+            className="mobile-menu__nav-link"
+          />
+        )}
       </div>
     </div>
   );

--- a/src/compositions/Page/Page.tsx
+++ b/src/compositions/Page/Page.tsx
@@ -1,16 +1,9 @@
-import React, { FC, ReactNode, useState } from 'react';
+import React, { FC, PropsWithChildren, useState } from 'react';
 
 import classNames from 'classnames';
 import { Helmet } from 'react-helmet';
 
 import Button from '../../components/Button/Button';
-import useEnsAddress from '../../hooks/useEnsAddress';
-import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { disableDemoAccount } from '../../redux/stores/config/configSlice';
-import { clearLastProviderFromLocalStorage } from '../../redux/stores/web3/web3Api';
-import { setShowConnectModal } from '../../redux/stores/web3/web3Slice';
-import { getConnection } from '../../web3-connectors/connections';
-import { tryDeactivateConnector } from '../../web3-connectors/helpers';
 import WalletConnector from '../../widgets/WalletConnector/WalletConnector';
 import MobileMenu from '../MobileMenu/MobileMenu';
 import TopBar from '../TopBar/TopBar';
@@ -18,23 +11,47 @@ import TopBar from '../TopBar/TopBar';
 import './Page.scss';
 
 interface PageProps {
-  children?: ReactNode;
+  isActive: boolean;
+  listButtonIsDisabled: boolean;
+  showConnectModal: boolean;
+  showDesktopConnectButton: boolean;
+  showDesktopUserButton: boolean;
+  showDisableDemoAccountButton: boolean;
+  showMobileMenuButton: boolean;
+  userWalletButtonIsDisabled: boolean;
+  account?: string;
+  avatarUrl?: string;
+  collectionName: string;
+  ensAddress?: string;
+  onConnectButtonClick: () => void;
+  onCloseWalletConnectorButtonClick: () => void;
+  onDisableDemoAccountButtonClick: () => void;
+  onDisconnectButtonClick: () => void;
   className?: string;
   contentClassName?: string;
 }
 
-const Page: FC<PageProps> = ({ className = '', contentClassName = '', children }) => {
-  const dispatch = useAppDispatch();
-
-  const { isActive, account, chainId } = useAppSelector(state => state.web3);
-  const { config } = useAppSelector((state) => state);
-  const { isInitialized, showConnectModal, connectionType } = useAppSelector((state) => state.web3);
-  const { avatarUrl } = useAppSelector((state) => state.user);
-
-  const ensAddress = useEnsAddress(account || '');
-
-  const chainIdIsCorrect = !!chainId && chainId === config.chainId;
-
+const Page: FC<PropsWithChildren<PageProps>> = ({
+  isActive,
+  listButtonIsDisabled,
+  onCloseWalletConnectorButtonClick,
+  showConnectModal,
+  showDesktopUserButton,
+  showDesktopConnectButton,
+  showDisableDemoAccountButton,
+  showMobileMenuButton,
+  userWalletButtonIsDisabled,
+  account,
+  avatarUrl,
+  collectionName,
+  ensAddress,
+  onConnectButtonClick,
+  onDisableDemoAccountButtonClick,
+  onDisconnectButtonClick,
+  className = '',
+  contentClassName = '',
+  children,
+}) => {
   const [mobileMenuIsVisible, setMobileMenuIsVisible] = useState(false);
 
   const pageClassName = classNames('page', {
@@ -45,57 +62,45 @@ const Page: FC<PageProps> = ({ className = '', contentClassName = '', children }
     setMobileMenuIsVisible(!mobileMenuIsVisible);
   };
 
-  const handleDisconnectButtonClick = (): void => {
-    if (!connectionType) {
-      return;
-    }
-
-    tryDeactivateConnector(getConnection(connectionType).connector);
-    clearLastProviderFromLocalStorage();
-  };
-
-  const toggleShowWalletConnector = (): void => {
-    dispatch(setShowConnectModal(!showConnectModal));
-  };
-
-  const handleDisableDemoAccountClick = (): void => {
-    dispatch(disableDemoAccount());
-  };
-
   return (
     <div className={pageClassName}>
       <Helmet>
-        <title>{config.collectionName}</title>
+        <title>{collectionName}</title>
       </Helmet>
+
       <TopBar
-        listButtonIsDisabled={!chainIdIsCorrect || !account}
+        listButtonIsDisabled={listButtonIsDisabled}
         mobileMenuIsVisible={mobileMenuIsVisible}
-        showDesktopConnectButton={isInitialized && !isActive}
-        showDesktopUserButton={isInitialized && isActive}
-        showDisableDemoAccountButton={config.isDemoAccount}
-        showMobileMenuButton={isActive}
-        userWalletButtonIsDisabled={!chainIdIsCorrect}
+        showDesktopConnectButton={showDesktopConnectButton}
+        showDesktopUserButton={showDesktopUserButton}
+        showDisableDemoAccountButton={showDisableDemoAccountButton}
+        showMobileMenuButton={showMobileMenuButton}
+        userWalletButtonIsDisabled={userWalletButtonIsDisabled}
         avatarUrl={avatarUrl}
         account={account}
         ensAddress={ensAddress}
-        onConnectButtonClick={toggleShowWalletConnector}
-        onDisableDemoAccountButtonClick={handleDisableDemoAccountClick}
-        onDisconnectButtonClick={handleDisconnectButtonClick}
+        onConnectButtonClick={onConnectButtonClick}
+        onDisableDemoAccountButtonClick={onDisableDemoAccountButtonClick}
+        onDisconnectButtonClick={onDisconnectButtonClick}
         onMobileMenuButtonClick={handleIconButtonClick}
         className="page__top-bar"
       />
+
       {(account && isActive) && (
         <MobileMenu
           isHidden={!mobileMenuIsVisible}
+          showDisableDemoAccountButton={showDisableDemoAccountButton}
           avatarUrl={avatarUrl}
           address={account}
+          onDisableDemoAccountButtonClick={onDisableDemoAccountButtonClick}
           onNavLinkClick={handleIconButtonClick}
-          onLogoutButtonClick={handleDisconnectButtonClick}
+          onLogoutButtonClick={onDisconnectButtonClick}
           className="page__mobile-menu"
         />
       )}
+
       <WalletConnector
-        onCloseButtonClick={toggleShowWalletConnector}
+        onCloseButtonClick={onCloseWalletConnectorButtonClick}
         className="page__wallet-connector"
       />
 
@@ -105,7 +110,7 @@ const Page: FC<PageProps> = ({ className = '', contentClassName = '', children }
         {(!isActive && !showConnectModal) && (
           <Button
             text="Connect wallet"
-            onClick={toggleShowWalletConnector}
+            onClick={onConnectButtonClick}
             className="page__connect-wallet-button"
           />
         )}

--- a/src/compositions/Page/Page.tsx
+++ b/src/compositions/Page/Page.tsx
@@ -6,6 +6,7 @@ import { Helmet } from 'react-helmet';
 import Button from '../../components/Button/Button';
 import useEnsAddress from '../../hooks/useEnsAddress';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { disableDemoAccount } from '../../redux/stores/config/configSlice';
 import { clearLastProviderFromLocalStorage } from '../../redux/stores/web3/web3Api';
 import { setShowConnectModal } from '../../redux/stores/web3/web3Slice';
 import { getConnection } from '../../web3-connectors/connections';
@@ -57,6 +58,10 @@ const Page: FC<PageProps> = ({ className = '', contentClassName = '', children }
     dispatch(setShowConnectModal(!showConnectModal));
   };
 
+  const handleDisableDemoAccountClick = (): void => {
+    dispatch(disableDemoAccount());
+  };
+
   return (
     <div className={pageClassName}>
       <Helmet>
@@ -67,12 +72,14 @@ const Page: FC<PageProps> = ({ className = '', contentClassName = '', children }
         mobileMenuIsVisible={mobileMenuIsVisible}
         showDesktopConnectButton={isInitialized && !isActive}
         showDesktopUserButton={isInitialized && isActive}
+        showDisableDemoAccountButton={config.isDemoAccount}
         showMobileMenuButton={isActive}
         userWalletButtonIsDisabled={!chainIdIsCorrect}
         avatarUrl={avatarUrl}
         account={account}
         ensAddress={ensAddress}
         onConnectButtonClick={toggleShowWalletConnector}
+        onDisableDemoAccountButtonClick={handleDisableDemoAccountClick}
         onDisconnectButtonClick={handleDisconnectButtonClick}
         onMobileMenuButtonClick={handleIconButtonClick}
         className="page__top-bar"

--- a/src/compositions/Page/Page.tsx
+++ b/src/compositions/Page/Page.tsx
@@ -67,6 +67,7 @@ const Page: FC<PageProps> = ({ className = '', contentClassName = '', children }
         mobileMenuIsVisible={mobileMenuIsVisible}
         showDesktopConnectButton={isInitialized && !isActive}
         showDesktopUserButton={isInitialized && isActive}
+        showMobileMenuButton={isActive}
         userWalletButtonIsDisabled={!chainIdIsCorrect}
         avatarUrl={avatarUrl}
         account={account}
@@ -76,12 +77,13 @@ const Page: FC<PageProps> = ({ className = '', contentClassName = '', children }
         onMobileMenuButtonClick={handleIconButtonClick}
         className="page__top-bar"
       />
-      {account && (
+      {(account && isActive) && (
         <MobileMenu
           isHidden={!mobileMenuIsVisible}
           avatarUrl={avatarUrl}
           address={account}
           onNavLinkClick={handleIconButtonClick}
+          onLogoutButtonClick={handleDisconnectButtonClick}
           className="page__mobile-menu"
         />
       )}

--- a/src/compositions/TopBar/TopBar.tsx
+++ b/src/compositions/TopBar/TopBar.tsx
@@ -22,12 +22,14 @@ interface TopBarProps {
   mobileMenuIsVisible: boolean;
   showDesktopConnectButton: boolean;
   showDesktopUserButton: boolean;
+  showDisableDemoAccountButton: boolean;
   showMobileMenuButton: boolean;
   userWalletButtonIsDisabled: boolean;
   account?: string;
   avatarUrl?: string;
   ensAddress: string | undefined;
   onConnectButtonClick: () => void;
+  onDisableDemoAccountButtonClick: () => void;
   onDisconnectButtonClick: () => void;
   onMobileMenuButtonClick: () => void;
   className?: string;
@@ -38,12 +40,14 @@ const TopBar: FC<TopBarProps> = ({
   mobileMenuIsVisible,
   showDesktopConnectButton,
   showDesktopUserButton,
+  showDisableDemoAccountButton,
   showMobileMenuButton,
   userWalletButtonIsDisabled,
   account,
   avatarUrl,
   ensAddress,
   onConnectButtonClick,
+  onDisableDemoAccountButtonClick,
   onDisconnectButtonClick,
   onMobileMenuButtonClick,
   className = '',
@@ -130,9 +134,11 @@ const TopBar: FC<TopBarProps> = ({
       </div>
       {isPopupOpen && (
         <UserPopup
+          showDisableDemoAccountButton={showDisableDemoAccountButton}
           address={account || undefined}
           ensAddress={ensAddress}
           ref={userPopupRef}
+          onDisableDemoAccountButtonClick={onDisableDemoAccountButtonClick}
           onLogoutButtonClick={handleDisconnectClick}
           className="top-bar__user-popup"
         />

--- a/src/compositions/TopBar/TopBar.tsx
+++ b/src/compositions/TopBar/TopBar.tsx
@@ -6,7 +6,6 @@ import React, {
 } from 'react';
 
 import classNames from 'classnames';
-import { NavLink } from 'react-router-dom';
 
 import Avatar from '../../components/Avatar/Avatar';
 import Button from '../../components/Button/Button';
@@ -23,6 +22,7 @@ interface TopBarProps {
   mobileMenuIsVisible: boolean;
   showDesktopConnectButton: boolean;
   showDesktopUserButton: boolean;
+  showMobileMenuButton: boolean;
   userWalletButtonIsDisabled: boolean;
   account?: string;
   avatarUrl?: string;
@@ -38,6 +38,7 @@ const TopBar: FC<TopBarProps> = ({
   mobileMenuIsVisible,
   showDesktopConnectButton,
   showDesktopUserButton,
+  showMobileMenuButton,
   userWalletButtonIsDisabled,
   account,
   avatarUrl,
@@ -87,7 +88,7 @@ const TopBar: FC<TopBarProps> = ({
         to="/"
         className="top-bar__airswap-button"
       />
-      {account && (
+      {showMobileMenuButton && (
         <IconButton
           hideLabel
           icon={!mobileMenuIsVisible ? 'menu' : 'close'}
@@ -115,14 +116,16 @@ const TopBar: FC<TopBarProps> = ({
         )}
         {showDesktopUserButton
           && (
-            <NavLink
-              aria-disabled={userWalletButtonIsDisabled}
-              to={routes.profile(ensAddress || account || '')}
+            <Button
+              disabled={userWalletButtonIsDisabled}
+              ref={userButtonRef}
+              text={truncateAddress(ensAddress || account || '')}
+              onClick={() => setIsPopupOpen(!isPopupOpen)}
               className="top-bar__user-button"
             >
               <Avatar avatarUrl={avatarUrl} className="top-bar__user-button-icon" />
               {truncateAddress(ensAddress || account || '')}
-            </NavLink>
+            </Button>
           )}
       </div>
       {isPopupOpen && (

--- a/src/compositions/UserPopup/UserPopup.scss
+++ b/src/compositions/UserPopup/UserPopup.scss
@@ -8,7 +8,7 @@ $component: user-popup;
     border: 1px solid var(--c-dark-border);
     border-radius: .25rem;
     width: 17.125rem;
-    padding: 0.5rem;
+    padding: .5rem .5rem 1rem;
     background: var(--c-dark);
 
     @include for-size(tablet-portrait-up) {
@@ -17,13 +17,15 @@ $component: user-popup;
 
     &__wallet-info {
         margin-bottom: 0.5rem;
+        padding-block: .5rem;
     }
 
     &__wallet-info-avatar {
         display: none;
     }
 
-    &__nav-link {
+    &__nav-link,
+    &__button {
         @extend %button;
         @extend %button-border-style;
 

--- a/src/compositions/UserPopup/UserPopup.scss
+++ b/src/compositions/UserPopup/UserPopup.scss
@@ -36,7 +36,6 @@ $component: user-popup;
         font-size: .875rem;
         
         &:hover, &:focus {
-            font-weight: var(--fw-500);
             color: var(--c-white);
             background-color: var(--c-grey);
         }

--- a/src/compositions/UserPopup/UserPopup.tsx
+++ b/src/compositions/UserPopup/UserPopup.tsx
@@ -25,21 +25,22 @@ export type UserPopupWithRefProps = UserPopupProps & RefAttributes<HTMLDivElemen
 const UserPopup: FC<UserPopupWithRefProps> = forwardRef(({
   address,
   ensAddress,
+  onLogoutButtonClick,
   className = '',
 }, ref: Ref<HTMLDivElement>): ReactElement => (
   <div ref={ref} className={`user-popup ${className}`}>
     <WalletInfo
       address={address}
+      showLogOutButton
       ensAddress={ensAddress}
+      onLogoutButtonClick={onLogoutButtonClick}
       className="user-popup__wallet-info"
       avatarClassName="user-popup__wallet-info-avatar"
     />
     {address && (
       <>
-        <NavLink to={routes.profile(address)} className="user-popup__nav-link">Profile</NavLink>
-        <NavLink to={routes.profile(address)} className="user-popup__nav-link">NFTs</NavLink>
-        <NavLink to={routes.userOrders(address)} className="user-popup__nav-link">Listed</NavLink>
-        <NavLink to={routes.activity(address)} className="user-popup__nav-link">Activity</NavLink>
+        <NavLink to={routes.profile(address)} className="user-popup__nav-link">My tokens</NavLink>
+        <NavLink to={routes.userOrders(address)} className="user-popup__nav-link">My listing</NavLink>
       </>
     )}
   </div>

--- a/src/compositions/UserPopup/UserPopup.tsx
+++ b/src/compositions/UserPopup/UserPopup.tsx
@@ -8,14 +8,17 @@ import {
 
 import { NavLink } from 'react-router-dom';
 
+import Button from '../../components/Button/Button';
 import WalletInfo from '../../components/WalletInfo/WalletInfo';
 import { routes } from '../../routes';
 
 import './UserPopup.scss';
 
 interface UserPopupProps {
+  showDisableDemoAccountButton: boolean;
   address?: string;
   ensAddress?: string;
+  onDisableDemoAccountButtonClick: () => void;
   onLogoutButtonClick: () => void;
   className?: string;
 }
@@ -23,8 +26,10 @@ interface UserPopupProps {
 export type UserPopupWithRefProps = UserPopupProps & RefAttributes<HTMLDivElement>;
 
 const UserPopup: FC<UserPopupWithRefProps> = forwardRef(({
+  showDisableDemoAccountButton,
   address,
   ensAddress,
+  onDisableDemoAccountButtonClick,
   onLogoutButtonClick,
   className = '',
 }, ref: Ref<HTMLDivElement>): ReactElement => (
@@ -42,6 +47,14 @@ const UserPopup: FC<UserPopupWithRefProps> = forwardRef(({
         <NavLink to={routes.profile(address)} className="user-popup__nav-link">My tokens</NavLink>
         <NavLink to={routes.userOrders(address)} className="user-popup__nav-link">My listing</NavLink>
       </>
+    )}
+    {showDisableDemoAccountButton && (
+      <Button
+        className="user-popup__button"
+        onClick={onDisableDemoAccountButtonClick}
+      >
+        Exit demo account
+      </Button>
     )}
   </div>
 ));

--- a/src/connectors/ConnectedPage/ConnectedPage.tsx
+++ b/src/connectors/ConnectedPage/ConnectedPage.tsx
@@ -1,0 +1,76 @@
+import { FC, PropsWithChildren, ReactElement } from 'react';
+
+import Page from '../../compositions/Page/Page';
+import useEnsAddress from '../../hooks/useEnsAddress';
+import { useAppDispatch, useAppSelector } from '../../redux/hooks';
+import { disableDemoAccount } from '../../redux/stores/config/configSlice';
+import { clearLastProviderFromLocalStorage } from '../../redux/stores/web3/web3Api';
+import { setShowConnectModal } from '../../redux/stores/web3/web3Slice';
+import { getConnection } from '../../web3-connectors/connections';
+import { tryDeactivateConnector } from '../../web3-connectors/helpers';
+
+interface ConnectedPageProps {
+  className?: string;
+  contentClassName?: string;
+}
+
+const ConnectedPage: FC<PropsWithChildren<ConnectedPageProps>> = ({
+  className = '',
+  contentClassName = '',
+  children,
+}): ReactElement => {
+  const dispatch = useAppDispatch();
+
+  const { isActive, account, chainId } = useAppSelector(state => state.web3);
+  const { config } = useAppSelector((state) => state);
+  const { isInitialized, showConnectModal, connectionType } = useAppSelector((state) => state.web3);
+  const { avatarUrl } = useAppSelector((state) => state.user);
+
+  const ensAddress = useEnsAddress(account || '');
+
+  const chainIdIsCorrect = !!chainId && chainId === config.chainId;
+
+  const handleDisconnectButtonClick = (): void => {
+    if (!connectionType) {
+      return;
+    }
+
+    tryDeactivateConnector(getConnection(connectionType).connector);
+    clearLastProviderFromLocalStorage();
+  };
+
+  const toggleShowWalletConnector = (): void => {
+    dispatch(setShowConnectModal(!showConnectModal));
+  };
+
+  const handleDisableDemoAccountClick = (): void => {
+    dispatch(disableDemoAccount());
+  };
+
+  return (
+    <Page
+      isActive={isActive}
+      listButtonIsDisabled={!chainIdIsCorrect || !account}
+      showConnectModal={showConnectModal}
+      showDesktopConnectButton={isInitialized && !isActive}
+      showDesktopUserButton={isInitialized && isActive}
+      showDisableDemoAccountButton={config.isDemoAccount}
+      showMobileMenuButton={isActive}
+      userWalletButtonIsDisabled={!chainIdIsCorrect}
+      avatarUrl={avatarUrl}
+      account={account}
+      collectionName={config.collectionName}
+      ensAddress={ensAddress}
+      onCloseWalletConnectorButtonClick={toggleShowWalletConnector}
+      onConnectButtonClick={toggleShowWalletConnector}
+      onDisableDemoAccountButtonClick={handleDisableDemoAccountClick}
+      onDisconnectButtonClick={handleDisconnectButtonClick}
+      className={className}
+      contentClassName={contentClassName}
+    >
+      {children}
+    </Page>
+  );
+};
+
+export default ConnectedPage;

--- a/src/helpers/indexers.ts
+++ b/src/helpers/indexers.ts
@@ -17,7 +17,12 @@ export const getUndefinedAfterTimeout = (time: number): Promise<undefined> => ne
   setTimeout(() => resolve(undefined), time);
 });
 
-export const getOrdersFromIndexers = async (filter: OrderFilter, indexerUrls: string[], provider: BaseProvider): Promise<ExtendedFullOrder[]> => {
+export const getOrdersFromIndexers = async (
+  filter: OrderFilter,
+  indexerUrls: string[],
+  provider: BaseProvider,
+  isDemoAccount?: boolean,
+): Promise<ExtendedFullOrder[]> => {
   if (!indexerUrls.length) {
     console.error('[getOrdersFromIndexers] No indexer urls provided');
   }
@@ -46,6 +51,6 @@ export const getOrdersFromIndexers = async (filter: OrderFilter, indexerUrls: st
   const validOrders = await getFullOrdersIsValid(uniqueOrders, provider);
 
   return uniqueOrders.map((fullOrder, index) => (
-    transformToExtendedFullOrder(fullOrder, noncesUsed[index], validOrders[index])
+    transformToExtendedFullOrder(fullOrder, noncesUsed[index], isDemoAccount || validOrders[index])
   ));
 };

--- a/src/hooks/useMapWeb3ReactToStore.ts
+++ b/src/hooks/useMapWeb3ReactToStore.ts
@@ -9,6 +9,7 @@ const useMapWeb3ReactToStore = (): void => {
   const dispatch = useAppDispatch();
 
   const { libraries } = useAppSelector((state) => state.web3);
+  const { impersonateAddress } = useAppSelector((state) => state.config);
 
   const {
     account,
@@ -21,7 +22,7 @@ const useMapWeb3ReactToStore = (): void => {
   useDebounce(() => {
     dispatch(setWeb3Data({
       isActive,
-      account: account || undefined,
+      account: impersonateAddress || account || undefined,
       chainId,
     }));
   }, 100, [

--- a/src/hooks/useMapWeb3ReactToStore.ts
+++ b/src/hooks/useMapWeb3ReactToStore.ts
@@ -29,6 +29,7 @@ const useMapWeb3ReactToStore = (): void => {
     isActive,
     account,
     chainId,
+    impersonateAddress,
     library,
   ]);
 

--- a/src/pages/CollectionPage/CollectionPage.tsx
+++ b/src/pages/CollectionPage/CollectionPage.tsx
@@ -1,19 +1,19 @@
 import React, { FC } from 'react';
 
 import Helmet from '../../compositions/Helmet/Helmet';
-import Page from '../../compositions/Page/Page';
+import ConnectedPage from '../../connectors/ConnectedPage/ConnectedPage';
 import CollectionWidget from '../../widgets/CollectionWidget/CollectionWidget';
 
 import './CollectionPage.scss';
 
 const CollectionPage: FC = () => (
-  <Page
+  <ConnectedPage
     className="collection-page"
     contentClassName="collection-page__content"
   >
     <Helmet title="All listings" />
     <CollectionWidget />
-  </Page>
+  </ConnectedPage>
 );
 
 export default CollectionPage;

--- a/src/pages/ListNftPage/ListNftPage.tsx
+++ b/src/pages/ListNftPage/ListNftPage.tsx
@@ -1,20 +1,20 @@
 import React, { FC } from 'react';
 
 import Helmet from '../../compositions/Helmet/Helmet';
-import Page from '../../compositions/Page/Page';
+import ConnectedPage from '../../connectors/ConnectedPage/ConnectedPage';
 import ListNftWidget from '../../widgets/ListNftWidget/ListNftWidget';
 
 import './ListNftPage.scss';
 
 const ListNftPage: FC = () => (
-  <Page className="list-nft-page">
+  <ConnectedPage className="list-nft-page">
     <Helmet title="List a token" />
     <div className="list-nft-page__list-nft-widget-cover">
       <div className="list-nft-page__list-nft-widget-container">
         <ListNftWidget className="list-nft-page__list-nft-widget" />
       </div>
     </div>
-  </Page>
+  </ConnectedPage>
 );
 
 export default ListNftPage;

--- a/src/pages/NftDetailPage/NftDetailPage.tsx
+++ b/src/pages/NftDetailPage/NftDetailPage.tsx
@@ -3,19 +3,19 @@ import React, { FC } from 'react';
 import { useParams } from 'react-router-dom';
 
 import Helmet from '../../compositions/Helmet/Helmet';
-import Page from '../../compositions/Page/Page';
+import ConnectedPage from '../../connectors/ConnectedPage/ConnectedPage';
 import NftDetailWidget from '../../widgets/NftDetailWidget/NftDetailWidget';
 
 const NftDetailPage: FC = () => {
   const { tokenId } = useParams<{ tokenId: string }>();
 
   return (
-    <Page>
+    <ConnectedPage>
       <Helmet title={`Token ${tokenId || 1}`} />
       <NftDetailWidget
         tokenId={tokenId || '1'}
       />
-    </Page>
+    </ConnectedPage>
   );
 };
 

--- a/src/pages/OrderDetailPage/OrderDetailPage.tsx
+++ b/src/pages/OrderDetailPage/OrderDetailPage.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 
 import DisconnectedOrderDetail from '../../compositions/DisconnectedOrderDetail/DisconnectedOrderDetail';
 import Helmet from '../../compositions/Helmet/Helmet';
-import Page from '../../compositions/Page/Page';
+import ConnectedPage from '../../connectors/ConnectedPage/ConnectedPage';
 import OrderDetailWidget from '../../widgets/OrderDetailWidget/OrderDetailWidget';
 
 import './OrderDetailPage.scss';
@@ -14,17 +14,17 @@ const OrderDetailPage: FC = () => {
 
   if (!orderNonce || !account) {
     return (
-      <Page className="order-detail-page">
+      <ConnectedPage className="order-detail-page">
         <DisconnectedOrderDetail isOrderNonceUndefined />
-      </Page>
+      </ConnectedPage>
     );
   }
 
   return (
-    <Page className="order-detail-page">
+    <ConnectedPage className="order-detail-page">
       <Helmet title="Order detail" />
       <OrderDetailWidget orderNonce={orderNonce} signerWallet={account} />
-    </Page>
+    </ConnectedPage>
   );
 };
 

--- a/src/pages/ProfileOrdersPage/ProfileOrdersPage.tsx
+++ b/src/pages/ProfileOrdersPage/ProfileOrdersPage.tsx
@@ -1,17 +1,17 @@
 import React, { FC } from 'react';
 
-import Page from '../../compositions/Page/Page';
+import ConnectedPage from '../../connectors/ConnectedPage/ConnectedPage';
 import ProfileOrdersWidget from '../../widgets/ProfileOrdersWidget/ProfileOrdersWidget';
 
 import './ProfileOrdersPage.scss';
 
 const ProfileOrdersPage: FC = () => (
-  <Page
+  <ConnectedPage
     className="profile-page"
     contentClassName="profile-page__content"
   >
     <ProfileOrdersWidget />
-  </Page>
+  </ConnectedPage>
 );
 
 export default ProfileOrdersPage;

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,17 +1,17 @@
 import React, { FC } from 'react';
 
-import Page from '../../compositions/Page/Page';
+import ConnectedPage from '../../connectors/ConnectedPage/ConnectedPage';
 import ProfileWidget from '../../widgets/ProfileWidget/ProfileWidget';
 
 import './ProfilePage.scss';
 
 const ProfilePage: FC = () => (
-  <Page
+  <ConnectedPage
     className="profile-page"
     contentClassName="profile-page__content"
   >
     <ProfileWidget />
-  </Page>
+  </ConnectedPage>
 );
 
 export default ProfilePage;

--- a/src/redux/stores/collection/collectionApi.ts
+++ b/src/redux/stores/collection/collectionApi.ts
@@ -18,12 +18,17 @@ ExtendedFullOrder[],
 GetCollectionOrdersParams,
 AppThunkApiConfig
 >('collection/getCollectionOrders', async ({ provider, ...filter }, { dispatch, getState }) => {
-  const { indexer } = getState();
+  const { config, indexer } = getState();
 
   dispatch(setOffset(filter.limit + filter.offset));
 
   try {
-    return await getOrdersFromIndexers(filter, indexer.urls, provider);
+    return await getOrdersFromIndexers(
+      filter,
+      indexer.urls,
+      provider,
+      config.isDemoAccount,
+    );
   } catch {
     dispatch(addGetOrderFailedToast());
 

--- a/src/redux/stores/config/configSlice.ts
+++ b/src/redux/stores/config/configSlice.ts
@@ -8,6 +8,7 @@ export interface ConfigState {
   hasFailedCollectionToken: boolean;
   hasFailedCurrencyToken: boolean;
   hasFailedSwapContract: boolean;
+  isDemoAccount: boolean;
   isLoadingCollectionTokenKind: boolean;
   isLoadingCurrencyTokenKind: boolean;
   chainId: number;
@@ -17,6 +18,7 @@ export interface ConfigState {
   collectionTokenKind?: TokenKinds;
   collectionName: string;
   collectionImage: string;
+  impersonateAddress?: string;
   storageServerUrl: string;
   swapContractAddress?: string | null;
 }
@@ -25,6 +27,7 @@ const initialState: ConfigState = {
   hasFailedCollectionToken: false,
   hasFailedCurrencyToken: false,
   hasFailedSwapContract: false,
+  isDemoAccount: !!process.env.REACT_APP_IMPERSONATE_ADDRESS,
   isLoadingCollectionTokenKind: false,
   isLoadingCurrencyTokenKind: false,
   chainId: process.env.REACT_APP_CHAIN_ID ? parseInt(process.env.REACT_APP_CHAIN_ID, 10) : 1,
@@ -32,6 +35,7 @@ const initialState: ConfigState = {
   collectionToken: (process.env.REACT_APP_COLLECTION_TOKEN || '').toLowerCase(),
   collectionName: process.env.REACT_APP_COLLECTION_NAME || '',
   collectionImage: process.env.REACT_APP_COLLECTION_IMAGE || '',
+  impersonateAddress: process.env.REACT_APP_IMPERSONATE_ADDRESS,
   storageServerUrl: process.env.REACT_APP_STORAGE_SERVER_URL || '',
 };
 

--- a/src/redux/stores/config/configSlice.ts
+++ b/src/redux/stores/config/configSlice.ts
@@ -48,7 +48,6 @@ const configSlice = createSlice({
     }),
     disableDemoAccount: (state): ConfigState => ({
       ...state,
-      isDemoAccount: false,
       impersonateAddress: undefined,
     }),
   },

--- a/src/redux/stores/config/configSlice.ts
+++ b/src/redux/stores/config/configSlice.ts
@@ -46,6 +46,11 @@ const configSlice = createSlice({
     reset: (): ConfigState => ({
       ...initialState,
     }),
+    disableDemoAccount: (state): ConfigState => ({
+      ...state,
+      isDemoAccount: false,
+      impersonateAddress: undefined,
+    }),
   },
   extraReducers: builder => {
     builder.addCase(getCollectionTokenKind.pending, (state): ConfigState => ({
@@ -88,7 +93,7 @@ const configSlice = createSlice({
   },
 });
 
-export const { reset } = configSlice.actions;
+export const { reset, disableDemoAccount } = configSlice.actions;
 
 export const selectConfigFailed = ({ config }: RootState): boolean => config.hasFailedCurrencyToken
     || config.hasFailedSwapContract

--- a/src/redux/stores/profileOrders/profileOrdersApi.ts
+++ b/src/redux/stores/profileOrders/profileOrdersApi.ts
@@ -17,12 +17,17 @@ ExtendedFullOrder[],
 GetProfileOrdersParams,
 AppThunkApiConfig
 >('profileOrders/getProfileOrders', async ({ provider, ...filter }, { dispatch, getState }) => {
-  const { indexer } = getState();
+  const { config, indexer } = getState();
 
   try {
     dispatch(setOrdersOffset((filter.limit || 0) + (filter.offset || 0)));
 
-    return await getOrdersFromIndexers(filter, indexer.urls, provider);
+    return await getOrdersFromIndexers(
+      filter,
+      indexer.urls,
+      provider,
+      config.isDemoAccount,
+    );
   } catch {
     dispatch(addGetOrderFailedToast());
 

--- a/src/widgets/ListNftWidget/subcomponents/ConnectedListNftWidget/ConnectedListNftWidget.tsx
+++ b/src/widgets/ListNftWidget/subcomponents/ConnectedListNftWidget/ConnectedListNftWidget.tsx
@@ -69,7 +69,7 @@ const ConnectedListNftWidget: FC<ListNftWidgetProps> = ({
   // Store data
   const { error: ordersError } = useAppSelector(state => state.orders);
   const { error: listNftError } = useAppSelector(state => state.listNft);
-  const { collectionToken, collectionName } = useAppSelector(state => state.config);
+  const { isDemoAccount, collectionToken, collectionName } = useAppSelector(state => state.config);
   const { protocolFee, projectFee } = useAppSelector(state => state.metadata);
 
   // User input states
@@ -84,9 +84,9 @@ const ConnectedListNftWidget: FC<ListNftWidgetProps> = ({
   const [currencyTokenAmountMinusProtocolFee, protocolFeeInCurrencyToken] = useTokenAmountAndFee(currencyTokenAmount);
   const [approvalTransactionHash, setApprovalTransactionHash] = useState<string>();
   const [order, setOrder] = useState<FullOrder>();
-  const hasInsufficientAmount = useInsufficientAmount(currencyTokenAmount);
+  const hasInsufficientAmount = useInsufficientAmount(currencyTokenAmount) || !isDemoAccount;
   const hasInsufficientExpiryAmount = !expiryAmount || expiryAmount < 0;
-  const hasCollectionTokenApproval = useNftTokenApproval(collectionTokenInfo, selectedTokenId);
+  const hasCollectionTokenApproval = useNftTokenApproval(collectionTokenInfo, selectedTokenId) || isDemoAccount;
   const approveTransaction = useApproveNftTransaction(approvalTransactionHash);
   const [indexedOrderResult, indexerError] = useIndexedOrderResult(order?.nonce);
   const activeUserOrder = userOrders.find(userOrder => userOrder.signer.id === selectedTokenId);


### PR DESCRIPTION
Fixes #205 
Fixes #207

Allows you to impersonate any account by filling in the `REACT_APP_IMPERSONATE_ADDRESS` in the `.env`.

This allows you to create orders and send them to indexers. All these orders are invalid because you're not the rightful owner of these nft's. But for demo purposes they appear valid.

After creating orders you can exit the demo mode by clicking on the "Exit demo account" button in the menu.

![Screenshot 2024-02-07 at 23 01 58](https://github.com/airswap/airswap-marketplace/assets/86911296/6bb47c6f-24b3-48d0-9506-dd22cb2c5909)

Also did some refactoring.
