### PR TITLE
set package homepage to . for relative assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "airswap-marketplace",
   "version": "0.1.0",
   "private": true,
+  "homepage": ".",
   "scripts": {
     "start": "craco --openssl-legacy-provider start",
     "build": "craco --openssl-legacy-provider build",


### PR DESCRIPTION
Allow app to be served from different paths.
Assets are currently linked to an absolute path:
```
/static/js/2.d8651403.chunk.js
```
With homepage as "." assets are linked relative to index.html:
```
./static/js/2.d8651403.chunk.js
```
Read more:
https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths